### PR TITLE
Table declaration changed

### DIFF
--- a/FSQLTest/src/test.fsql
+++ b/FSQLTest/src/test.fsql
@@ -1,10 +1,11 @@
+
 create database DB1
 
 use database DB1
 
 Table1.init() 
 
-Table1.schema(id : INT as primary key, name : STRING )
+Table1.schema(id : INT as primary key, name : BOOL )
 
 Table1.addColumn(age:INT)
 
@@ -12,9 +13,9 @@ Table1.addRow({name = "Teofana",age = 5})
 
 Table1.addRows({name = "John",age=7},{name="Julia" ,age=10})
 
-// error if we want to access col1
-// Table1.where(col1 lt 6).delete()
-
+//// error if we want to access col1
+//// Table1.where(col1 lt 6).delete()
+//
 Table1.where(age eq 1).delete()
 
 Table1.delete()
@@ -35,7 +36,7 @@ Table1.modify(col4:BOOL,col5:STRING)
 
 Table2.init()
 
-Table2.schema(id:INT, name :STRING)
+Table2.schema(id:INT as primary key, name : STRING references Table1)
 //
 Table1.innerJoin(Table2).on(Table1.name = Table2.name).where(id eq 1).select(name, age)
 Table1.leftJoin(Table2).on(Table1.name = Table2.name).select(name,age)

--- a/uk.ac.kcl.language.fsql/bin/uk/ac/kcl/language/fsql/FSQL.xtext
+++ b/uk.ac.kcl.language.fsql/bin/uk/ac/kcl/language/fsql/FSQL.xtext
@@ -42,15 +42,25 @@ import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
 
 FSQL:
-	createDB+=CreateDB+
-	useDB+=UseDB
-	initTable+=InitTable+
-	declareSchema+=SchemaDeclaration+
+	dbStatements+=DatabaseStatements*
 	tableStatements+=TableStatements*
 ;
 
+DatabaseStatements:
+	CreateDB | UseDB
+;
+
+// I have also added the database statements because we can change the db or create a new one
 TableStatements:
-	AddRow | AddRows | DropTable | Delete | Update | AlterTable | Join | Query | InitTable | SchemaDeclaration | CreateDB | UseDB
+	CreateTable | TableStatement
+;
+
+CreateTable:
+	InitTable | SchemaDeclaration
+;
+
+TableStatement:
+	AddRows | AddRow | DropTable | Delete | Update | AlterTable | Join | Query
 ;
 	
 CreateDB:
@@ -70,12 +80,12 @@ InitTable :
 	 name=ID '.' 'init()'
 ;
 
-SchemaDeclaration:
-	table+=TableDeclaration '.' 'schema' '(' column+=ColumnDeclaration  (',' columns+=ColumnDeclaration)* ')'
-;
-
 TableDeclaration:
 	var = [InitTable]
+;
+
+SchemaDeclaration:
+	table+=TableDeclaration '.' 'schema' '(' column+=ColumnDeclaration  (',' columns+=ColumnDeclaration)* ')'
 ;
 
 DropTable:

--- a/uk.ac.kcl.language.fsql/src/uk/ac/kcl/language/fsql/FSQL.xtext
+++ b/uk.ac.kcl.language.fsql/src/uk/ac/kcl/language/fsql/FSQL.xtext
@@ -42,15 +42,25 @@ import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
 
 FSQL:
-	createDB+=CreateDB+
-	useDB+=UseDB
-	initTable+=InitTable+
-	declareSchema+=SchemaDeclaration+
+	dbStatements+=DatabaseStatements*
 	tableStatements+=TableStatements*
 ;
 
+DatabaseStatements:
+	CreateDB | UseDB
+;
+
+// I have also added the database statements because we can change the db or create a new one
 TableStatements:
-	AddRow | AddRows | DropTable | Delete | Update | AlterTable | Join | Query | InitTable | SchemaDeclaration | CreateDB | UseDB
+	CreateTable | TableStatement
+;
+
+CreateTable:
+	InitTable | SchemaDeclaration
+;
+
+TableStatement:
+	AddRows | AddRow | DropTable | Delete | Update | AlterTable | Join | Query
 ;
 	
 CreateDB:
@@ -70,12 +80,12 @@ InitTable :
 	 name=ID '.' 'init()'
 ;
 
-SchemaDeclaration:
-	table+=TableDeclaration '.' 'schema' '(' column+=ColumnDeclaration  (',' columns+=ColumnDeclaration)* ')'
-;
-
 TableDeclaration:
 	var = [InitTable]
+;
+
+SchemaDeclaration:
+	table+=TableDeclaration '.' 'schema' '(' column+=ColumnDeclaration  (',' columns+=ColumnDeclaration)* ')'
 ;
 
 DropTable:


### PR DESCRIPTION
The table declaration rule was changed such that its columns can be further referenced from any other rule which requires column access. 

This new table declaration type excludes the possibility of referencing inexistent columns => less validations needed

Further actions:
- addRows rule
- grammar refactoring
- restrictions in terms of accessing table statement rules (update, modify etc.). unless the schema of a table has not been declared